### PR TITLE
Clarification for installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Download the xpi from [Releases](https://github.com/ThomasFKJorna/zotero-night/r
 
 https://user-images.githubusercontent.com/21983833/168032714-6106b138-2725-4091-830b-770dbdff43a4.mov
 
-Once installed in Zotero, activate it: Tools > Nogth Preferences, and select "Enable Dark Theme".
+Once installed in Zotero, activate it: Tools > Night Preferences, and select "Enable Dark Theme".
 
 ## 😢 Limitations
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Download the xpi from [Releases](https://github.com/ThomasFKJorna/zotero-night/r
 
 https://user-images.githubusercontent.com/21983833/168032714-6106b138-2725-4091-830b-770dbdff43a4.mov
 
+Once installed in Zotero, activate it: Tools > Nogth Preferences, and select "Enable Dark Theme".
+
 ## 😢 Limitations
 
 - Popup menus do not have proper styling on some platforms.


### PR DESCRIPTION
Since it happened to me, I would like prevent other from wasting time to understand how activate the plugin, once installed.

The video instructions for installation are a bit misleading, since the theme is automatically activated once installed, which is not the case in the lastes version. you have to manually activate it from Tool > Night Preferences. To improve this, I added this info in the README :)